### PR TITLE
データベース名の変更

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -19,14 +19,14 @@ default: &default
 
 development:
   <<: *default
-  database: mercari-clone_development
+  database: freemarket_sample_53a_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: mercari-clone_test
+  database: freemarket_sample_53a_test
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -49,7 +49,7 @@ test:
 #
 production:
   <<: *default
-  database: mercari-clone_production
+  database: freemarket_sample_53a_production
   username: <%= Rails.application.credentials.db[:username] %>
   password: <%= Rails.application.credentials.db[:password] %>
   socket: /var/lib/mysql/mysql.sock


### PR DESCRIPTION
# WHAT
データベース名の変更
# WHY
rails newした際にアプリケーション名を間違えたため