### PR TITLE
エラー発生時のビュー及び、routeの名前を少し変える

### DIFF
--- a/app/assets/stylesheets/modules/_registration.scss
+++ b/app/assets/stylesheets/modules/_registration.scss
@@ -263,9 +263,6 @@
                 transform: translate(0, -50%);
               }
             }
-            &__text-center {
-              text-align: center;
-            }
           }
           &__btn {
             @include button();

--- a/app/helpers/registration_helper.rb
+++ b/app/helpers/registration_helper.rb
@@ -1,4 +1,9 @@
 module RegistrationHelper
+
+  def has_error(errors)
+    errors.present? ? "has-error" : ""
+  end
+
   def years
     years = []
     (Time.current.year-119..Time.current.year).reverse_each do |year|

--- a/app/views/users/registrations/deliver_address.html.haml
+++ b/app/views/users/registrations/deliver_address.html.haml
@@ -29,23 +29,23 @@
             = f.label :full_name, "お名前"
             %span.registration-form__content__form-group__form-require 必須
             %br/
-            = f.text_field :last_name, autocomplete: "last_name", class: "registration-form__content__form-group__input", placeholder: "例）山田"
+            = f.text_field :last_name, autocomplete: "last_name", class: "registration-form__content__form-group__input #{has_error(@deliver_address.errors[:last_name])}", placeholder: "例）山田"
             = render "shared/user_errors", errors: @deliver_address.errors[:last_name]
-            = f.text_field :first_name, autocomplete: "first_name", class: "registration-form__content__form-group__input", placeholder: "例）彩"
+            = f.text_field :first_name, autocomplete: "first_name", class: "registration-form__content__form-group__input #{has_error(@deliver_address.errors[:first_name])}", placeholder: "例）彩"
             = render "shared/user_errors", errors: @deliver_address.errors[:first_name]
           .registration-form__content__form-group
             = f.label :full_name, "お名前カナ"
             %span.registration-form__content__form-group__form-require 必須
             %br/
-            = f.text_field :last_name_kana, autocomplete: "last_name_kana", class: "registration-form__content__form-group__input", placeholder: "例）ヤマダ"
+            = f.text_field :last_name_kana, autocomplete: "last_name_kana", class: "registration-form__content__form-group__input #{has_error(@deliver_address.errors[:last_name_kana])}", placeholder: "例）ヤマダ"
             = render "shared/user_errors", errors: @deliver_address.errors[:last_name_kana]
-            = f.text_field :first_name_kana, autocomplete: "first_name_kana", class: "registration-form__content__form-group__input", placeholder: "例）アヤ"
+            = f.text_field :first_name_kana, autocomplete: "first_name_kana", class: "registration-form__content__form-group__input #{has_error(@deliver_address.errors[:first_name_kana])}", placeholder: "例）アヤ"
             = render "shared/user_errors", errors: @deliver_address.errors[:first_name_kana]
           .registration-form__content__form-group
             = f.label :zipcode, "郵便番号"
             %span.registration-form__content__form-group__form-require 必須
             %br/
-            = f.text_field :zipcode, autocomplete: "last_name_kana", class: "registration-form__content__form-group__input", placeholder: "例）123-4567"
+            = f.text_field :zipcode, autocomplete: "last_name_kana", class: "registration-form__content__form-group__input #{has_error(@deliver_address.errors[:zipcode])}", placeholder: "例）123-4567"
             = render "shared/user_errors", errors: @deliver_address.errors[:zipcode]
           .registration-form__content__form-group
             = f.label :prefecture, "都道府県"
@@ -57,25 +57,25 @@
             = f.label :city, "市区町村"
             %span.registration-form__content__form-group__form-require 必須
             %br/
-            = f.text_field :city, autocomplete: "city", class: "registration-form__content__form-group__input", placeholder: "例）横浜市緑区"
+            = f.text_field :city, autocomplete: "city", class: "registration-form__content__form-group__input #{has_error(@deliver_address.errors[:city])}", placeholder: "例）横浜市緑区"
             = render "shared/user_errors", errors: @deliver_address.errors[:city]
           .registration-form__content__form-group
             = f.label :house_address, "番地"
             %span.registration-form__content__form-group__form-require 必須
             %br/
-            = f.text_field :house_address, autocomplete: "house_address", class: "registration-form__content__form-group__input", placeholder: "例）青山1-1-1"
+            = f.text_field :house_address, autocomplete: "house_address", class: "registration-form__content__form-group__input #{has_error(@deliver_address.errors[:house_address])}", placeholder: "例）青山1-1-1"
             = render "shared/user_errors", errors: @deliver_address.errors[:house_address]
           .registration-form__content__form-group
             = f.label :building_name, "建物名"
             %span.registration-form__content__form-group__form-arbitrary 任意
             %br/
-            = f.text_field :building_name, autocomplete: "building_name", class: "registration-form__content__form-group__input", placeholder: "例）柳ビル103"
+            = f.text_field :building_name, autocomplete: "building_name", class: "registration-form__content__form-group__input #{has_error(@deliver_address.errors[:building_name])}", placeholder: "例）柳ビル103"
             = render "shared/user_errors", errors: @deliver_address.errors[:building_name]
           .registration-form__content__form-group
             = f.label :phone_number, "電話"
             %span.registration-form__content__form-group__form-arbitrary 任意
             %br/
-            = f.text_field :phone_number, autocomplete: "phone_number", class: "registration-form__content__form-group__input", placeholder: "例）09012345678"
+            = f.text_field :phone_number, autocomplete: "phone_number", class: "registration-form__content__form-group__input #{has_error(@deliver_address.errors[:phone_number])}", placeholder: "例）09012345678"
             = render "shared/user_errors", errors: @deliver_address.errors[:phone_number]
           = f.submit "次へ進む", class: "registration-form__content__btn"
   %footer.registration__footer

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -29,25 +29,25 @@
             = f.label :nickname, "ニックネーム"
             %span.registration-form__content__form-group__form-require 必須
             %br/
-            = f.text_field :nickname, autocomplete: "nickname", class: "registration-form__content__form-group__input", placeholder: "例）メルカリ太郎"
+            = f.text_field :nickname, autocomplete: "nickname", class: "registration-form__content__form-group__input #{has_error(@user.errors[:nickname])}", placeholder: "例）メルカリ太郎"
             = render "shared/user_errors", errors: @user.errors[:nickname]
           .registration-form__content__form-group
             = f.label :email, "メールアドレス"
             %span.registration-form__content__form-group__form-require 必須
             %br/
-            = f.email_field :email, autocomplete: "email", class: "registration-form__content__form-group__input", placeholder: "PC・携帯どちらでも可"
+            = f.email_field :email, autocomplete: "email", class: "registration-form__content__form-group__input #{has_error(@user.errors[:email])}", placeholder: "PC・携帯どちらでも可"
             = render "shared/user_errors", errors: @user.errors[:email]
           .registration-form__content__form-group
             = f.label :password, "パスワード"
             %span.registration-form__content__form-group__form-require 必須
             %br/
-            = f.password_field :password, autocomplete: "new-password", class: "registration-form__content__form-group__input", placeholder: "7文字以上"
+            = f.password_field :password, autocomplete: "new-password", class: "registration-form__content__form-group__input #{has_error(@user.errors[:password])}", placeholder: "7文字以上"
             = render "shared/user_errors", errors: @user.errors[:password]
           .registration-form__content__form-group
             = f.label :password_confirmation, "パスワード(確認)"
             %span.registration-form__content__form-group__form-require 必須
             %br/
-            = f.password_field :password_confirmation, autocomplete: "new-password", class: "registration-form__content__form-group__input", placeholder: "7文字以上"
+            = f.password_field :password_confirmation, autocomplete: "new-password", class: "registration-form__content__form-group__input #{has_error(@user.errors[:password_confirmation])}", placeholder: "7文字以上"
             = render "shared/user_errors", errors: @user.errors[:password_confirmation]
           .registration-form__content__form-group
             %h3.registration-form__content__form-group__sub-head 本人確認
@@ -57,16 +57,16 @@
             %label お名前(全角)
             %span.registration-form__content__form-group__form-require 必須
             %br/
-            = f.text_field :last_name, autocomplete: "last_name", class: "registration-form__content__form-group__input registration-form__content__form-group__input--last_name half", placeholder: "例）山田"
-            = f.text_field :first_name, autocomplete: "first_name", class: "registration-form__content__form-group__input half", placeholder: "例）彩"
+            = f.text_field :last_name, autocomplete: "last_name", class: "registration-form__content__form-group__input registration-form__content__form-group__input--last_name half #{has_error(@user.errors[:last_name])}", placeholder: "例）山田"
+            = f.text_field :first_name, autocomplete: "first_name", class: "registration-form__content__form-group__input half #{has_error(@user.errors[:first_name])}", placeholder: "例）彩"
             = render "shared/user_errors", errors: @user.errors[:last_name]
             = render "shared/user_errors", errors: @user.errors[:first_name]
           .registration-form__content__form-group
             %label お名前カナ(全角)
             %span.registration-form__content__form-group__form-require 必須
             %br/
-            = f.text_field :last_name_kana, autocomplete: "last_name_kana", class: "registration-form__content__form-group__input registration-form__content__form-group__input--last_name_kana half", placeholder: "例）ヤマダ"
-            = f.text_field :first_name_kana, autocomplete: "first_name_kana", class: "registration-form__content__form-group__input half", placeholder: "例）アヤ"
+            = f.text_field :last_name_kana, autocomplete: "last_name_kana", class: "registration-form__content__form-group__input registration-form__content__form-group__input--last_name_kana half #{has_error(@user.errors[:last_name_kana])}", placeholder: "例）ヤマダ"
+            = f.text_field :first_name_kana, autocomplete: "first_name_kana", class: "registration-form__content__form-group__input half #{has_error(@user.errors[:first_name_kana])}", placeholder: "例）アヤ"
             = render "shared/user_errors", errors: @user.errors[:last_name_kana]
             = render "shared/user_errors", errors: @user.errors[:first_name_kana]
           .registration-form__content__form-group
@@ -77,15 +77,15 @@
             .registration-form__content__form-group__birthday-select
               .registration-form__content__form-group__birthday-select-wrap
                 = fa_icon "chevron-down", class: "fa-chevron-down-year"
-                = select_tag :year, options_for_select(years), prompt: "--", class: "registration-form__content__form-group__birthday-select-wrap__select"
+                = select_tag :year, options_for_select(years), prompt: "--", class: "registration-form__content__form-group__birthday-select-wrap__select #{has_error(@user.errors[:birth_date])}"
               %span 年
               .registration-form__content__form-group__birthday-select-wrap
                 = fa_icon "chevron-down", class: "fa-chevron-down-month"
-                = select_tag :month, options_for_select(months), prompt: "--", class: "registration-form__content__form-group__birthday-select-wrap__select"
+                = select_tag :month, options_for_select(months), prompt: "--", class: "registration-form__content__form-group__birthday-select-wrap__select #{has_error(@user.errors[:birth_date])}"
               %span 月
               .registration-form__content__form-group__birthday-select-wrap
                 = fa_icon "chevron-down", class: "fa-chevron-down-day"
-                = select_tag :day, options_for_select([["--",""]]), class: "registration-form__content__form-group__birthday-select-wrap__select"
+                = select_tag :day, options_for_select([["--",""]]), class: "registration-form__content__form-group__birthday-select-wrap__select #{has_error(@user.errors[:birth_date])}"
               %span 日
             .clearfix
               = render "shared/user_errors", errors: @user.errors[:birth_date]
@@ -93,10 +93,6 @@
             ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
         .registration-form__content
           .registration-form__content__form-group
-            %p.registration-form__content__form-group__text-center
-              「次へ進む」のボタンを押すことにより、
-              %a{:href => "#"}> 利用規約
-              に同意したものとみなします
           = f.submit "次へ進む", class: "registration-form__content__btn"
   %footer.registration__footer
     = link_to root_path, class: "registration__footer__logo" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   }
 
   devise_scope :user do
-    get "log_in", to: "users/sessions#new"
+    get "login", to: "users/sessions#new"
     get "logout", to: "users/sessions#logout"
     delete "logout", to: "users/sessions#destroy"
     get "registrations/sms_confirmation", to: "users/registrations#sms_confirmation"


### PR DESCRIPTION
# What
エラー発生時のビュー作成。
get "log_in"をget "login"に。

# Why
エラー時のビューのみ未作成。
get "logout"と名前を合わせる。

# 備考
電話番号認証機能次第ではクラスの追加の仕方が変わるかもしれない。
deliver_addressの都道府県のところのみgemを入れたあとに実装。

[![Image from Gyazo](https://i.gyazo.com/1df91046b67868670768095c98008354.gif)](https://gyazo.com/1df91046b67868670768095c98008354)