### PR TITLE
ランダムパスワードの生成に関する微修正

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -86,7 +86,8 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def set_password
-    password = Devise.friendly_token.first(16)
+    password = Devise.friendly_token.first(14)
+    password.insert(rand(14), rand(9).to_s).insert(rand(15), ("A".."Z").to_a[rand(26)])
     params[:user][:password] = password
     params[:user][:password_confirmation] = password
   end


### PR DESCRIPTION
# What
ランダムパスワード生成時、英字数字が入るように。

# Why
deviseのランダム文字列生成では英字数字がそれぞれ最低一文字以上入っている保証がなく、どちらかが欠けた状態でランダム生成されれば、パスワードがうまく生成されず、SNS認証が失敗するため。