### PR TITLE
パンくず機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,3 +106,6 @@ gem 'dotenv-rails'
 gem "omniauth-rails_csrf_protection"
 gem 'omniauth-facebook'
 gem 'omniauth-google-oauth2'
+
+# パンくず
+gem "gretel"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,8 @@ GEM
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gretel (3.0.9)
+      rails (>= 3.1.0)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
@@ -388,6 +390,7 @@ DEPENDENCIES
   faker
   fog-aws
   font-awesome-rails
+  gretel
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,6 +8,7 @@
 
 @import "./modules/header_guide";
 @import "./modules/category";
+@import "./modules/_breadcrumbs";
 @import "./modules/footer";
 @import "./modules/footer_btn";
 @import "./modules/banner";

--- a/app/assets/stylesheets/modules/_breadcrumbs.scss
+++ b/app/assets/stylesheets/modules/_breadcrumbs.scss
@@ -1,0 +1,18 @@
+.breadcrumbs-wrap {
+  height: 48px;
+  line-height: 48px;
+  background: $white;
+  border-top: 1px solid $gray;
+  font-size: 14px;
+  padding-left: 90;
+  &__breadcrumbs{
+    width: 1020px;
+    margin: auto;
+  }
+  a {
+    color: #333;
+  }
+  .current {
+    font-weight: bold;
+  }
+}

--- a/app/assets/stylesheets/modules/_registration.scss
+++ b/app/assets/stylesheets/modules/_registration.scss
@@ -105,6 +105,10 @@
         line-height: 1.5;
         text-align: center;
         font-weight: bold;
+        &--mypage {
+          font-size: 24px;
+          padding: 8px 24px;
+        }
       }
       .registration-form {
         padding: 40px 40px 64px;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,10 @@
 class UsersController < ApplicationController
   def show
   end
+
+  def deliver_address
+    # 現在、deliver_addressのテーブルがないためuserで代理
+    # Todo UserをDeliverAddressに変更
+    @deliver_address = User.new
+  end
 end

--- a/app/views/items/mypage_item_show.html.haml
+++ b/app/views/items/mypage_item_show.html.haml
@@ -1,5 +1,4 @@
 = render 'items/header_guide'
-
 .detail-item
   %h1.detail-item__name=@item.name
 

--- a/app/views/shared/_breadcrumbs.html.haml
+++ b/app/views/shared/_breadcrumbs.html.haml
@@ -1,0 +1,2 @@
+.breadcrumbs-wrap
+  = breadcrumbs separator: "&nbsp;&nbsp;&rsaquo;&nbsp;&nbsp;".html_safe, class: "breadcrumbs-wrap__breadcrumbs"

--- a/app/views/users/credit_cards/new.html.haml
+++ b/app/views/users/credit_cards/new.html.haml
@@ -1,5 +1,6 @@
+- breadcrumb :credit_card
 = render 'items/header_guide'
-
+= render 'shared/breadcrumbs'
 %main.mypage-container.clearfix
 
   .content

--- a/app/views/users/credit_cards/show.html.haml
+++ b/app/views/users/credit_cards/show.html.haml
@@ -1,5 +1,6 @@
+- breadcrumb :credit_card
 = render 'items/header_guide'
-
+= render 'shared/breadcrumbs'
 %main.mypage-container.clearfix
 
   .content

--- a/app/views/users/deliver_address.html.haml
+++ b/app/views/users/deliver_address.html.haml
@@ -1,0 +1,67 @@
+- breadcrumb :deliver_address
+= render 'items/header_guide'
+= render 'shared/breadcrumbs'
+%main.mypage-container.clearfix
+  .content
+    %section.registration__main__section
+      %h2.registration__main__section__head.registration__main__section__head--mypage 発送元・お届け先住所変更
+      = form_with model: @deliver_address, class: "registration-form" do |f|
+        .registration-form__content
+          .registration-form__content__form-group.registration-form__content__form-group-first
+            = f.label :full_name, "お名前"
+            %span.registration-form__content__form-group__form-require 必須
+            %br/
+            = f.text_field :last_name, autocomplete: "last_name", class: "registration-form__content__form-group__input #{has_error(@deliver_address.errors[:last_name])}", placeholder: "例) 山田"
+            = render "shared/user_errors", errors: @deliver_address.errors[:last_name]
+            = f.text_field :first_name, autocomplete: "first_name", class: "registration-form__content__form-group__input #{has_error(@deliver_address.errors[:first_name])}", placeholder: "例) 彩"
+            = render "shared/user_errors", errors: @deliver_address.errors[:first_name]
+          .registration-form__content__form-group
+            = f.label :full_name, "お名前カナ"
+            %span.registration-form__content__form-group__form-require 必須
+            %br/
+            = f.text_field :last_name_kana, autocomplete: "last_name_kana", class: "registration-form__content__form-group__input #{has_error(@deliver_address.errors[:last_name_kana])}", placeholder: "例) ヤマダ"
+            = render "shared/user_errors", errors: @deliver_address.errors[:last_name_kana]
+            = f.text_field :first_name_kana, autocomplete: "first_name_kana", class: "registration-form__content__form-group__input #{has_error(@deliver_address.errors[:first_name_kana])}", placeholder: "例) アヤ"
+            = render "shared/user_errors", errors: @deliver_address.errors[:first_name_kana]
+          .registration-form__content__form-group
+            = f.label :zipcode, "郵便番号"
+            %span.registration-form__content__form-group__form-require 必須
+            %br/
+            = f.text_field :zipcode, autocomplete: "last_name_kana", class: "registration-form__content__form-group__input #{has_error(@deliver_address.errors[:zipcode])}", placeholder: "例) 123-4567"
+            = render "shared/user_errors", errors: @deliver_address.errors[:zipcode]
+          .registration-form__content__form-group
+            = f.label :prefecture, "都道府県"
+            %span.registration-form__content__form-group__form-require 必須
+            .registration-form__content__form-group__prefecture-select-wrap
+              = fa_icon "chevron-down"
+              = f.select :prefecture, [["北海道", "北海道"]], {}, {class: "registration-form__content__form-group__prefecture-select-wrap__select"}
+          .registration-form__content__form-group
+            = f.label :city, "市区町村"
+            %span.registration-form__content__form-group__form-require 必須
+            %br/
+            = f.text_field :city, autocomplete: "city", class: "registration-form__content__form-group__input #{has_error(@deliver_address.errors[:city])}", placeholder: "例) 横浜市緑区"
+            = render "shared/user_errors", errors: @deliver_address.errors[:city]
+          .registration-form__content__form-group
+            = f.label :house_address, "番地"
+            %span.registration-form__content__form-group__form-require 必須
+            %br/
+            = f.text_field :house_address, autocomplete: "house_address", class: "registration-form__content__form-group__input #{has_error(@deliver_address.errors[:house_address])}", placeholder: "例) 青山1-1-1"
+            = render "shared/user_errors", errors: @deliver_address.errors[:house_address]
+          .registration-form__content__form-group
+            = f.label :building_name, "建物名"
+            %span.registration-form__content__form-group__form-arbitrary 任意
+            %br/
+            = f.text_field :building_name, autocomplete: "building_name", class: "registration-form__content__form-group__input #{has_error(@deliver_address.errors[:building_name])}", placeholder: "例) 柳ビル103"
+            = render "shared/user_errors", errors: @deliver_address.errors[:building_name]
+          .registration-form__content__form-group
+            = f.label :phone_number, "電話"
+            %span.registration-form__content__form-group__form-arbitrary 任意
+            %br/
+            = f.text_field :phone_number, autocomplete: "phone_number", class: "registration-form__content__form-group__input #{has_error(@deliver_address.errors[:phone_number])}", placeholder: "例) 09012345678"
+            = render "shared/user_errors", errors: @deliver_address.errors[:phone_number]
+          = f.submit "変更する", class: "registration-form__content__btn"
+
+  = render 'users/mypage/side'
+  = render 'items/footer_btn'
+
+= render 'items/footer'

--- a/app/views/users/identification.html.haml
+++ b/app/views/users/identification.html.haml
@@ -1,5 +1,6 @@
+- breadcrumb :identification
 = render 'items/header_guide'
-
+= render 'shared/breadcrumbs'
 %main.mypage-container.clearfix
 
   = render 'users/mypage/side'

--- a/app/views/users/mypage/_side.html.haml
+++ b/app/views/users/mypage/_side.html.haml
@@ -2,7 +2,7 @@
   %nav
     %ul.items
       %li
-        = link_to root_path, class: "items__item active" do
+        = link_to current_user, class: "items__item active" do
           マイページ
           %i.icon-arrow-right
       %li
@@ -80,7 +80,7 @@
           プロフィール
           %i.icon-arrow-right
       %li
-        = link_to root_path, class: "items__item" do
+        = link_to deliver_address_user_path(current_user), class: "items__item" do
           発送元・お届け先住所変更
           %i.icon-arrow-right
       %li

--- a/app/views/users/profile.html.haml
+++ b/app/views/users/profile.html.haml
@@ -1,5 +1,6 @@
+- breadcrumb :profile
 = render 'items/header_guide'
-
+= render 'shared/breadcrumbs'
 %main.mypage-container.clearfix
   = render 'users/mypage/side'
 

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -3,7 +3,7 @@
   %main.registration__main
     %section.registration__main__section
       %h2.registration__main__section__head 会員情報入力
-      = form_with model: @user, url: user_registration_path, id: 'new_user', class: 'registration-form', local: true do |f|
+      = form_with model: @user, url: sign_up_path, id: 'new_user', class: 'registration-form', local: true do |f|
         .registration-form__content
           .registration-form__content__form-group.registration-form__content__form-group-first
             = f.label :nickname, "ニックネーム"

--- a/app/views/users/sessions/sign_out.html.haml
+++ b/app/views/users/sessions/sign_out.html.haml
@@ -1,5 +1,6 @@
+- breadcrumb :sign_out, current_user
 = render 'items/header_guide'
-
+= render 'shared/breadcrumbs'
 %main.mypage-container.clearfix
 
   .content

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,5 +1,6 @@
+- breadcrumb :mypage
 = render 'items/header_guide'
-
+= render 'shared/breadcrumbs'
 %main.mypage-container.clearfix
   = render 'users/mypage/content'
   = render 'users/mypage/side'

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,56 @@
+crumb :root do
+  link "メルカリ", root_path
+end
+
+# トップページ以下
+crumb :mypage do
+  link "マイページ", user_path(current_user)
+  parent :root
+end
+
+# マイページ以下
+crumb :profile do
+  link "プロフィール", profile_user_path(current_user)
+  parent :mypage
+end
+
+crumb :deliver_address do
+  link " 発送元・お届け先住所変更", deliver_address_user_path(current_user)
+  parent :mypage
+end
+
+crumb :credit_card do
+  link "支払い方法", user_credit_card_path(current_user)
+  parent :mypage
+end
+
+crumb :identification do
+  link "本人情報", identification_user_path(current_user)
+  parent :mypage
+end
+
+crumb :sign_out do
+  link "ログアウト", sign_out_path
+  parent :mypage
+end
+
+# crumb :project do |project|
+#   link project.name, project_path(project)
+#   parent :projects
+# end
+
+# crumb :project_issues do |project|
+#   link "Issues", project_issues_path(project)
+#   parent :project, project
+# end
+
+# crumb :issue do |issue|
+#   link issue.title, issue_path(issue)
+#   parent :project_issues, issue.project
+# end
+
+# If you want to split your breadcrumbs configuration over multiple files, you
+# can create a folder named `config/breadcrumbs` and put your configuration
+# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
+# folder are loaded and reloaded automatically when you change them, just like
+# this file (`config/breadcrumbs.rb`).

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
     # 新規登録画面
     get "sign_up/top", to: "users/registrations#top"
     get "sign_up", to: "users/registrations#new"
+    post "sign_up", to: "users/registrations#create"
     get "sign_up/sms_authorization", to: "users/registrations#sms_authorization"
     get "sign_up/deliver_address", to: "users/registrations#deliver_address"
     get "sign_up/credit_card", to: "users/registrations#credit_card"
@@ -36,6 +37,7 @@ Rails.application.routes.draw do
     member do
       get :profile
       get :identification
+      get :deliver_address
     end
   end
 


### PR DESCRIPTION
# What
パンくず機能を実装した。
あと、作られていなかったページを、別ページをコピペするだけで作れたので、パンくずの実装ついでに作りました。
さらに、フォームで送信されるときのpathもちょっと変更していますが、こちらは全く気にする必要がないです。

# Why
自分が現在どのページにいるのか、ユーザーがわかりやすいようにするため。

[![Image from Gyazo](https://i.gyazo.com/af087aff0165b10721592f4c7b571a8d.gif)](https://gyazo.com/af087aff0165b10721592f4c7b571a8d)